### PR TITLE
3.0.0 Enhance ChangeLog and refactor scripts for Docker Compose v2 support

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 For build level release notes see https://github.com/mtconnect/cppagent/
 
+---
+
+## Types of changes
+
+### `Added` for new features.
+
+### `Changed` for changes in existing functionality.
+
+### `Deprecated` for soon-to-be removed features.
+
+### `Removed` for now removed features.
+
+### `Fixed` for any bug fixes.
+
+### `Security` in case of vulnerabilities.
+
+---
+
 ## [Unreleased]
+
+## [3.0.0] - 2025/03/25 - Max Harris
+
+### Changed
+
+- Refactored the ssUpgrade.sh and ssInstall.sh scripts to nativly support the new docker-compose v2 commands by auto-detecting the docker-compose version.
+- Refactored the ssUpgrade.sh script to run in parallel
+
+### Deprecated
+
+- Removed the -1 and -2 options in the ssUpgrade.sh, ssInstall.sh, and ssClean.sh scripts
 
 ## [2.3.3] - 2024/12/26 - Max Harris
 
@@ -244,17 +273,3 @@ For build level release notes see https://github.com/mtconnect/cppagent/
 ### Added
 
 - This is the intial revisioned release of the code.
-
-## Types of changes
-
-### `Added` for new features.
-
-### `Changed` for changes in existing functionality.
-
-### `Deprecated` for soon-to-be removed features.
-
-### `Removed` for now removed features.
-
-### `Fixed` for any bug fixes.
-
-### `Security` in case of vulnerabilities.

--- a/ssClean.sh
+++ b/ssClean.sh
@@ -8,7 +8,7 @@ Help(){
     echo "This function uninstalls HEMSaw MTConnect-SmartAdapter, ODS, MTconnect Agent and MQTT."
     echo "Any associated device files for MTConnect and Adapter files are deleted as per this repo."
     echo
-    echo "Syntax: ssClean.sh [-A|-H|-a|-M|-O|-C|-S|-d|-D|-1|-L|-h]"
+    echo "Syntax: ssClean.sh [-A|-H|-a|-M|-O|-C|-S|-d|-D|-L|-h]"
     echo "options:"
     echo "-A                    Uninstall ALL"
     echo "-H                    Uninstall the HEMsaw adapter application"
@@ -19,7 +19,6 @@ Help(){
     echo "-S                    Uninstall the HEMSaw MongoDB application"
     echo "-d                    Disable mongod, ods, and agent daemons"
     echo "-D                    Uninstall Docker"
-    echo "-1                    Use the docker V1 scripts for Ubuntu 22.04 and earlier base OS"
     echo "-L Container_Name     Log repair for any NULL or ^@ char"
     echo "-h                    Print this Help."
 }
@@ -176,14 +175,20 @@ run_uninstall_devctl=false
 run_uninstall_mongodb=false
 run_uninstall_docker=false
 run_uninstall_daemon=false
-Use_Docker_Compose_v1=false
 clean_logs=false
+
+# Auto-detect Docker Compose version
+if command -v docker-compose &> /dev/null; then
+    Use_Docker_Compose_v1=true
+else
+    Use_Docker_Compose_v1=false
+fi
 
 ############################################################
 # Process the input options. Add options as needed.        #
 ############################################################
 # Get the options
-while getopts ":L:HaAMDhOCSd1" option; do
+while getopts ":L:HaAMDhOCSd" option; do
     case ${option} in
         h) # display Help
             Help
@@ -212,8 +217,6 @@ while getopts ":L:HaAMDhOCSd1" option; do
             run_uninstall_docker=true;;
         d) # uninstall daemon
             run_uninstall_daemon=true;;
-        1) # Run the Docker Compose V1
-            Use_Docker_Compose_v1=true;;
         L) # run the docker log clean;;
             container_name=$OPTARG
             clean_logs=true;;

--- a/ssInstall.sh
+++ b/ssInstall.sh
@@ -8,7 +8,7 @@ Help(){
     echo "This function installs the HEMSaw MTConnect-SmartAdapter, ODS, Devctl, MTconnect Agent and MQTT."
     echo "The function uses the Docker Compose V1 script. To use the V1 script use -1"
     echo
-    echo "Syntax: ssInstall.sh [-h|-a File_Name|-j File_Name|-d File_Name|-c File_Name|-u Serial_number|-1|-f]"
+    echo "Syntax: ssInstall.sh [-h|-a File_Name|-j File_Name|-d File_Name|-c File_Name|-u Serial_number|-f]"
     echo "options:"
     echo "-a File_Name          Declare the afg file name; Defaults to - SmartSaw_DC_HA.afg"
     echo "-j File_Name          Declare the JSON file name; Defaults to - SmartSaw_alarms.json"
@@ -16,7 +16,6 @@ Help(){
     echo "-c File_Name          Declare the Device control config file name; Defaults to - devctl_json_config.json"
     echo "-u Serial_number      Declare the serial number for the uuid; Defaults to - SmartSaw"
     echo "-b                    Use the MQTT bridge configuration file name; Defaults to - mosq_bridge.conf"
-    echo "-1                    Use the docker V1 scripts for Ubuntu 22.04 and earlier base OS"
     echo "-f                    Force install of the files"
     echo "-h                    Print this Help."
     echo "AFG files"
@@ -192,15 +191,20 @@ else
 fi
 
 Use_MQTT_Bridge=false
-Use_Docker_Compose_v1=false
 force_install_files=false
 
+# Auto-detect Docker Compose version
+if command -v docker-compose &> /dev/null; then
+    Use_Docker_Compose_v1=true
+else
+    Use_Docker_Compose_v1=false
+fi
 
 ############################################################
 # Process the input options. Add options as needed.        #
 ############################################################
 # Get the options
-while getopts ":a:j:d:c:u:bh1f" option; do
+while getopts ":a:j:d:c:u:bhf" option; do
     case ${option} in
         h) # display Help
             Help
@@ -222,8 +226,6 @@ while getopts ":a:j:d:c:u:bh1f" option; do
             sed -i "7 s/.*/export Serial_Number=\"$Serial_Number\"/" env.sh;;
         b) # Run MQTT Bridge
             Use_MQTT_Bridge=true;;
-        1) # Run the Docker Compose V1
-            Use_Docker_Compose_v1=true;;
         f) # Force install files
             force_install_files=true;;
         \?) # Invalid option

--- a/ssUpgrade.sh
+++ b/ssUpgrade.sh
@@ -8,7 +8,7 @@ Help(){
     echo "This function updates HEMSaw MTConnect-SmartAdapter, ODS, Devctl, MTconnect Agent and MQTT."
     echo "Any associated device files for MTConnect and Adapter files are updated as per this repo."
     echo
-    echo "Syntax: ssUpgrade.sh [-A|-a File_Name|-j File_Name|-d File_Name|-c File_Name|-u Serial_number|-b|-i|-m|-1|-h]"
+    echo "Syntax: ssUpgrade.sh [-A|-a File_Name|-j File_Name|-d File_Name|-c File_Name|-u Serial_number|-b|-i|-m|-h]"
     echo "options:"
     echo "-A                Update the MTConnect Agent, HEMsaw adapter, ODS, MQTT, Devctl and Mongodb application"
     echo "-a File_Name      Declare the afg file name; Defaults to - SmartSaw_DC_HA.afg"
@@ -19,7 +19,6 @@ Help(){
     echo "-b                Update the MQTT broker to use the bridge configuration; runs - mosq_bridge.conf"
     echo "-i                ReInit the MongoDB parts and job databases"
     echo "-m                Update the MongoDB database with default materials"
-    echo "-1                Use the docker V1 scripts for Ubuntu 22.04 and earlier base OS"
     echo "-h                Print this Help."
     echo ""
     echo "AFG files"
@@ -422,7 +421,13 @@ run_update_mongodb=false
 run_update_materials=false
 run_init_jp=false
 run_install=false
-Use_Docker_Compose_v1=false
+
+# Auto-detect Docker Compose version
+if command -v docker-compose &> /dev/null; then
+    Use_Docker_Compose_v1=true
+else
+    Use_Docker_Compose_v1=false
+fi
 
 # check if install or upgrade
 if [[ ! -f /etc/mtconnect/config/agent.cfg ]]; then
@@ -446,7 +451,7 @@ fi
 # Process the input options. Add options as needed.        #
 ############################################################
 # Get the options
-while getopts ":a:j:d:c:u:Ahbmi1" option; do
+while getopts ":a:j:d:c:u:Ahbmi" option; do
     case ${option} in
         h) # display Help
             Help
@@ -479,8 +484,6 @@ while getopts ":a:j:d:c:u:Ahbmi1" option; do
             run_init_jp=true;;
         b) # Enter MQTT Bridge file name
             run_update_mqtt_bridge=true;;
-        1) # Run the Docker Compose V1
-            Use_Docker_Compose_v1=true;;
         \?) # Invalid option
             echo "ERROR[1] - Invalid option chosen"
             Help


### PR DESCRIPTION
- Updated ChangeLog.md to include new sections for types of changes and added details for version 3.0.0.
- Refactored ssUpgrade.sh, ssInstall.sh, and ssClean.sh scripts to remove deprecated options for Docker Compose v1 and implement auto-detection for Docker Compose version.