### PR TITLE
Auto-detect docker-compose version instead of using flag

### DIFF
--- a/ssInstall.sh
+++ b/ssInstall.sh
@@ -151,10 +151,13 @@ InstallDepency(){
     echo "Installing Docker..."
     apt update --fix-missing
     apt upgrade --fix-missing -y
-    if $Use_Docker_Compose_v1; then
-        apt install -y docker-compose python3-pip --fix-missing
-    else
+    # Check if docker-compose-v2 is available in apt
+    if apt-cache show docker-compose-v2 >/dev/null 2>&1; then
+        echo "Installing docker-compose-v2..."
         apt install -y docker-compose-v2 python3-pip --fix-missing
+    else
+        echo "docker-compose-v2 not available, falling back to docker-compose..."
+        apt install -y docker-compose python3-pip --fix-missing
     fi
     apt clean
 }

--- a/ssUpgrade.sh
+++ b/ssUpgrade.sh
@@ -110,15 +110,13 @@ RunDocker(){
             docker compose up --remove-orphans -d
         fi
     else
-        echo "Installing and Starting up the Docker images"
-        if $Use_Docker_Compose_v1; then
-            apt update --fix-missing
-            apt install -y docker-compose-v1 --fix-missing
-            docker-compose up --remove-orphans -d
+        # Check if docker-compose-v2 is available in apt
+        if apt-cache show docker-compose-v2 >/dev/null 2>&1; then
+            echo "Installing docker-compose-v2..."
+            apt install -y docker-compose-v2 python3-pip --fix-missing
         else
-            apt update --fix-missing
-            apt install -y docker-compose --fix-missing
-            docker compose up --remove-orphans -d
+            echo "docker-compose-v2 not available, falling back to docker-compose..."
+            apt install -y docker-compose python3-pip --fix-missing
         fi
         apt clean
     fi


### PR DESCRIPTION
AI: Update docker-compose installation to auto-detect availability

The script now checks if docker-compose-v2 is available in the apt repository and installs it if found, otherwise falls back to the traditional docker-compose package. This replaces the previous approach that relied on a manual configuration flag.